### PR TITLE
Hooks for OnGlyphInitForLevel and OnEffectApplyGlyphIsLocked 

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -24887,6 +24887,13 @@ void Player::InitGlyphsForLevel()
     if (level >= 80)
         value |= 0x20;
 
+    // @tswow-begin
+    FIRE(PlayerOnGlyphInitForLevel
+        , TSPlayer(this)
+        , TSMutable<uint32>(&value)
+    );
+    // @tswow-end
+
     SetUInt32Value(PLAYER_GLYPHS_ENABLED, value);
 }
 

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -3921,7 +3921,7 @@ void Spell::EffectApplyGlyph()
     bool isLocked = minLevel && player->GetLevel() < minLevel;
     FIRE_MAP(
           m_spellInfo->events
-        , SpellOnEffectApplyGlyphIsLocked
+        , SpellOnEffectApplyGlyph
         , TSSpell(this)
         , TSMutable<bool>(&isLocked)
     );

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -3916,7 +3916,18 @@ void Spell::EffectApplyGlyph()
         case 4: minLevel = 70; break;
         case 5: minLevel = 80; break;
     }
-    if (minLevel && player->GetLevel() < minLevel)
+
+    // @tswow-begin
+    bool isLocked = minLevel && player->GetLevel() < minLevel;
+    FIRE(
+        PlayerOnEffectApplyGlyphIsLocked
+        , m_glyphIndex
+        , TSMutable<bool>(&isLocked)
+        , TSPlayer(player)
+    );
+
+    if (isLocked)
+    // @tswow-end
     {
         SendCastResult(SPELL_FAILED_GLYPH_SOCKET_LOCKED);
         return;

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -3923,7 +3923,6 @@ void Spell::EffectApplyGlyph()
           m_spellInfo->events
         , SpellOnEffectApplyGlyphIsLocked
         , TSSpell(this)
-        , m_glyphIndex
         , TSMutable<bool>(&isLocked)
     );
 

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -3919,11 +3919,12 @@ void Spell::EffectApplyGlyph()
 
     // @tswow-begin
     bool isLocked = minLevel && player->GetLevel() < minLevel;
-    FIRE(
-        PlayerOnEffectApplyGlyphIsLocked
+    FIRE_MAP(
+          m_spellInfo->events
+        , SpellOnEffectApplyGlyphIsLocked
+        , TSSpell(this)
         , m_glyphIndex
         , TSMutable<bool>(&isLocked)
-        , TSPlayer(player)
     );
 
     if (isLocked)


### PR DESCRIPTION
Added hooks for OnGlyphInitForLevel and OnEffectApplyGlyphIsLocked to allow control over when the glyph is unlocked (also works in client interface) and enabled.

Should not require further changes in the interface to work.
Exception is the "Unlocks at level X" text, that would require manual changes.

Theoretically allows for more glyph slots. I managed to add a 7th but couldn't get the client side to actually send the request, but there should be little stopping this from working otherwise.