### PR TITLE
core/player: emit loading info OnCanEquip

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -11557,6 +11557,7 @@ InventoryResult Player::CanEquipItem(uint8 slot, uint16 &dest, Item* pItem, bool
                 , TSPlayer(const_cast<Player*>(this))
                 , slot
                 , swap
+                , not_loading
                 , TSMutableNumber<uint32>(&evtRes)
             );
             return InventoryResult(evtRes);


### PR DESCRIPTION
This commit adds the `not_loading` bool to the OnCanEquip event. This is required if devs want to check that `OnCanEquip` is not called when loading. As equipping of items might depend on _other_ items, which at login are not yet considered equipped, `OnCanEquip` could previously fail.

E.g. this simple example which just checks for a custom strength requirement of an item:
```typescript
events.Item.OnCanEquip((item, player, slot, swap,  result) =>{
        let entry = item.GetEntry()
        let hasTag = HAS_TAG(entry, "wog-core", "stat-req")
        if(hasTag) {
            // Check if the player has not enough strength.
            let strReq = getStrRequirement(entry)
            if (player.GetStat(STAT_STR) < strReq){
                result.set(2)
                player.SendBroadcastMessage(`You require ${strReq} strength`)
            }

        }
    })
```
Currently this would fail on a login if the strength requirement is only hit via other items.
The working code with the fix from this PR looks like this:
```typescript
events.Item.OnCanEquip((item, player, slot, swap, notLoading, result) =>{
        // If we're loading in, we don't want to check for stat requirements, as
        // the server may not consider all the items that may affect the player's
        // stats yet.
        if (!notLoading){
            return
        }
        let entry = item.GetEntry()
        let hasTag = HAS_TAG(entry, "wog-core", "stat-req")
        if(hasTag) {
            // Check if the player has not enough strength.
            let strReq = getStrRequirement(entry)
            if (player.GetStat(STAT_STR) < strReq){
                result.set(2)
                player.SendBroadcastMessage(`You require ${strReq} strength`)
            }

        }
    })
```
