### PR TITLE
Fix macOS build (clang 15+)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,9 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable (sol2)
 target_compile_definitions(sol2 INTERFACE SOL_NO_CHECK_NUMBER_PRECISION)
+# Force usage of "nil" in Sol2.
+# This is necessary for Apple platforms (e.g. macOS) where it considers "nil" to be a reserved keyword
+target_compile_definitions(sol2 INTERFACE SOL_NO_NIL=0)
 
 #
 # sourcemap

--- a/cmake/compiler/clang/settings.cmake
+++ b/cmake/compiler/clang/settings.cmake
@@ -147,9 +147,12 @@ if(BUILD_SHARED_LIBS)
     INTERFACE
       -fvisibility=hidden)
 
-  # --no-undefined to throw errors when there are undefined symbols
-  # (caused through missing TRINITY_*_API macros).
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --no-undefined")
+  # Throw errors when there are undefined symbols (caused through missing TRINITY_*_API macros)
+  # This is the default behavior on macOS since clang 15. Explicitly setting this flag raises a warning
+  # See https://stackoverflow.com/a/77526119/3672398
+  if (NOT CMAKE_CXX_COMPILER_ID MATCHES "AppleClang")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --no-undefined")
+  endif ()
 
   message(STATUS "Clang: Disallow undefined symbols")
 endif()


### PR DESCRIPTION
**Changes proposed**:

Small fixes to build core on macOS. Works on Clang 15+

- Remove superfluous `--no-undefined` flag
- Force usage of `nil` keyword (Sol2)

**Tests performed**: 
Core has been built, server started and was able to enter world (tswow full install):

<img width="1344" height="30" alt="image" src="https://github.com/user-attachments/assets/babcf31f-801a-4fd6-83bc-80f0a37f1107" />

___Small note___: this is my first contrib to wow emu in general, so if something is missing or unclear, please tell me. Thank you very much for your time!