### PR TITLE
Removes sql file that improperly initializes creature_template_outfits table

### DIFF
--- a/sql/custom/world/2020_07_12_00_world_dressnpcs_tswow.sql
+++ b/sql/custom/world/2020_07_12_00_world_dressnpcs_tswow.sql
@@ -1,1 +1,2 @@
-INSERT INTO `creature_template_outfits` VALUES (0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "tswow");
+INSERT INTO `creature_template_outfits` (`entry`, `race`, `gender`, `skin`, `face`, `hair`, `haircolor`, `facialhair`, `head`, `shoulders`, `body`, `chest`, `waist`, `legs`, `feet`, `wrists`, `hands`, `back`, `tabard`)
+VALUES (3000000123, 11, 1, 14, 4, 10, 3, 5, -31286, -43617, 0, -26267, -26270, -26272, 0, 0, -43698, 0, 0);


### PR DESCRIPTION
**Problem**: every TSWoW install will see this error in their logs:
```
Outfit entry 0 in creature_template_outfits has too low entry (entry <= 0). Ignoring.
```

**Why?**: Entries for creature_outfits table must be greater than 0x7FFFFFFF = 2,147,483,647 per [ObjectMgr::LoadCreatureOutfits()](https://github.com/tswow/TrinityCore/blob/c2b35b47373d69745be0062c574254f4f2c95aef/src/server/game/Globals/ObjectMgr.cpp#L9737) and [the DressNPCs README](https://github.com/tswow/TrinityCore/blob/c797f13b2c9f5a1a2fadef03eab660ffb675800d/src/server/scripts/Custom/DressNPCs/README.md).

If no entry exists in creature_template_outfits table, then we see:
```
 Loaded 0 creature outfits. DB table `creature_template_outfits` is empty!
```

However, in TSWoW's TC fork, we have [this SQL](https://github.com/tswow/TrinityCore/blob/tswow/sql/custom/world/2020_07_12_00_world_dressnpcs_tswow.sql) ([commit](https://github.com/tswow/TrinityCore/commit/489a8a51a905d54196fa0044ee5b26d2cfe605fb)) file that is loaded on every `--rebuild` of datascripts:
```
INSERT INTO `creature_template_outfits` VALUES (0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "tswow");
```

This is a minor problem because we are adding a row to `creature_template_outfits` that has an entry < 2,147,483,647 and thus are seeing this server error thrown.

**Fix**: This fix makes it so that the creature_template_outfits table is initialized properly and no error is thrown.
