### PR TITLE
cmake: Skip --no-undefined linker flag on macOS

### DIFF
--- a/cmake/compiler/clang/settings.cmake
+++ b/cmake/compiler/clang/settings.cmake
@@ -149,7 +149,9 @@ if(BUILD_SHARED_LIBS)
 
   # --no-undefined to throw errors when there are undefined symbols
   # (caused through missing TRINITY_*_API macros).
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --no-undefined")
-
-  message(STATUS "Clang: Disallow undefined symbols")
+  # Only apply on Linux - macOS ld64 doesn't support this flag
+  if(UNIX AND NOT APPLE)
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --no-undefined")
+    message(STATUS "Clang: Disallow undefined symbols")
+  endif()
 endif()


### PR DESCRIPTION
The ld64 linker on macOS doesn't support the --no-undefined flag, which is only needed on Linux. Conditionally apply this flag only on Linux systems.

Resolves https://github.com/tswow/tswow/issues/935 when combined with https://github.com/tswow/tswow/pull/936
